### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Launch script:
 
 > bash runDocker.sh
 
-Volume (-v): Replace /home/leo/Documents/SandBox path by your local path to real time project.
-
 # To configure it:
 
 Configuration is made in exec.sh at python function call:


### PR DESCRIPTION
After making the path to the project dynamic in the runDocker.sh file, there is no need for changing the path manually; therefore this suggestion is removed from the README file.